### PR TITLE
Fixes Issue #64 (SampleDataConfigTest test repository list fails sometimes)

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.0" />
+    <option name="version" value="1.8.10" />
   </component>
 </project>

--- a/src/test/kotlin/de/fenste/ms/address/config/SampleDataConfigTest.kt
+++ b/src/test/kotlin/de/fenste/ms/address/config/SampleDataConfigTest.kt
@@ -24,16 +24,19 @@ import de.fenste.ms.address.infrastructure.repositories.StateRepository
 import de.fenste.ms.address.infrastructure.repositories.StreetRepository
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 @SpringBootTest
 @ActiveProfiles("sample")
+@SuppressWarnings("LongParameterList")
 class SampleDataConfigTest(
+    @Autowired private val sampleData: SampleDataConfig,
     @Autowired private val countryRepository: CountryRepository,
     @Autowired private val stateRepository: StateRepository,
     @Autowired private val cityRepository: CityRepository,
@@ -47,6 +50,11 @@ class SampleDataConfigTest(
             assertFalse(empty(), message.invoke())
             this.forEach { println(it) }
         }
+    }
+
+    @BeforeTest
+    fun `set up`() {
+        sampleData.reset()
     }
 
     @Test


### PR DESCRIPTION
The test file was missing the `setUp()` function that adds sample data to the repositrories.
If this test file would be run as the first test all repositories would be empty otherwise resulting in a failure of the test.